### PR TITLE
Add linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # godot-format
 
-A godot/gdscript formatter extension for VSCode. It uses [GDScript-formatter](https://github.com/GDQuest/GDScript-formatter) by GDQuest.
+A godot/gdscript formatter and linter extension for VSCode. It uses [GDScript-formatter](https://github.com/GDQuest/GDScript-formatter) by GDQuest.
 
 ## Features
 
-This is a standard VSCode formatter and as such supports typical formatter capabilities like the format command or autoformatting on save.
+This extension provides:
+
+- **Formatting**: Standard VSCode formatter capabilities including format command and autoformatting on save
+- **Linting**: Highlights style and convention issues in your GDScript files
+
+The linter runs automatically when you save a file and displays warnings and errors inline with your code.
 
 ## Requirements
 
-This extension ships with the gdscript formatter binary for your specific platform at version `0.11.1` and uses it by default.
+This extension ships with the gdscript formatter binary for your specific platform at version `0.12.0` and uses it by default.
 If you want to provide your own binary, you can retrieve the one for your platform [here](https://github.com/GDQuest/GDScript-formatter/releases). You can either add it to your system's PATH for autodiscovery or specify the path to the executable in the extension settings (see below). If the binary is added to PATH, make sure to remove the platform and architecture from the filename, e.g. rename `gdscript-formatter-windows-x86_64.exe` to `gdscript-formatter.exe` or `gdscript-formatter-linux-aarch64` to `gdscript-formatter`. Then disable the `useBuiltInBinary` setting.
 
 ## Extension Settings
@@ -22,6 +27,11 @@ This extension supports the following settings:
 - `godotFormatter.indentSize`: How many spaces to use for indentation. This is only used if `useSpaces` is enabled
 - `godotFormatter.reorderCode`:Whether to allow reordering code blocks, like exported variables vs constants etc. This only applies if safe mode is disabled.
 - `godotFormatter.safe`: Whether to enable safe mode. Safe mode tries to preserve existing syntax and structure where possible and otherwise does not format the file. If this enabled, `reorderCode` is ignored. Slightly less performant.
+- `godotFormatter.enableLinter`: Enable/disable linting with this extension
+- `godotFormatter.linterMaxLineLength`: Configure the maximum line length for the liner. Default: 100.
+- `godotFormatter.linterIgnoredRules`: Comma-separated list of rules to ignore.
+  - [See the GDScript-formatter README](https://github.com/GDQuest/GDScript-formatter) for a full list of rules
+  - _NOTE:_ Rules can also be ignored with a `# gdlint-ignore-next-line (rules)` above a line or `# gdlint-ignore (rules)` next to a line.
 
 ## Known Issues
 
@@ -30,3 +40,20 @@ None so far
 ## Release Notes
 
 See [changelog](https://marketplace.visualstudio.com/items/DoHe.godot-format/changelog)
+
+## Testing locally
+
+1. Run `get-binary.sh (architecture)`
+   - [See versions here](https://github.com/GDQuest/GDScript-formatter/releases)
+   - Supported architectures:
+     - `linux-x86_64`
+     - `linux-aarch64`
+     - `windows-x86_64`
+     - `windows-aarch64`
+     - `macos-x86_64`
+     - `macos-aarch64`
+   - This places the binary at `binaries/gdscript-formatter`
+2. Run `npm install`
+3. Run `npx @vscode/vsce package`
+   - This will generate a `.vsix` file at the root of this project
+   - Install the `.vsix` from the VSCode extension menu

--- a/get-binary.sh
+++ b/get-binary.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-DEFAULT_VERSION="0.11.1"
+DEFAULT_VERSION="0.12.0"
 VALID_TARGETS=("linux-x86_64" "linux-aarch64" "windows-x86_64" "windows-aarch64" "macos-x86_64" "macos-aarch64")
 
 TARGET="$1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "godot-format",
-  "version": "0.0.1",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "godot-format",
-      "version": "0.0.1",
+      "version": "0.2.4",
+      "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "22.x",

--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
   "name": "godot-format",
   "displayName": "godot-format",
-  "description": "A formatter for Godot/GDScript using GDQuest's gdscript formatter",
-  "version": "0.2.3",
+  "description": "A formatter and linter for Godot/GDScript using GDQuest's gdscript formatter",
+  "version": "0.2.4",
   "engines": {
     "vscode": "^1.104.0"
   },
   "license": "MIT",
   "publisher": "DoHe",
   "categories": [
-    "Formatters"
+    "Formatters",
+    "Linters"
   ],
   "galleryBanner": {
     "color": "#478cbf",
@@ -24,7 +25,9 @@
     "godot",
     "gdscript",
     "formatter",
-    "format"
+    "format",
+    "linter",
+    "lint"
   ],
   "repository": {
     "type": "git",
@@ -50,6 +53,11 @@
           "type": "boolean",
           "default": true,
           "description": "Enable/disable formatting with this extension"
+        },
+        "godotFormatter.enableLinter": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable linting with this extension"
         },
         "godotFormatter.useBuiltInBinary": {
           "type": "boolean",
@@ -80,6 +88,16 @@
           "type": "boolean",
           "default": true,
           "description": "Whether to enable safe mode. Safe mode tries to preserve existing syntax and structure where possible and otherwise does not format the file. If this enabled, `reorderCode` is ignored. Slightly less performant."
+        },
+        "godotFormatter.linterMaxLineLength": {
+          "type": "integer",
+          "default": 100,
+          "description": "Maximum line length for the linter. Lines longer than this will be flagged as warnings."
+        },
+        "godotFormatter.linterIgnoredRules": {
+          "type": "string",
+          "default": "",
+          "description": "Comma-separated list of linter rules to ignore (e.g., 'class-name,signal-name')."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,11 +8,15 @@ const DEFAULT_EXECUTABLE = "gdscript-formatter";
 const BUILT_IN_BINARY_PATH = path.join(__dirname, "..", "binaries", DEFAULT_EXECUTABLE);
 
 let outputChannel: vscode.OutputChannel;
+let diagnosticCollection: vscode.DiagnosticCollection;
 
 
 export function activate(context: vscode.ExtensionContext) {
 	outputChannel = vscode.window.createOutputChannel("Godot Formatter");
+	diagnosticCollection = vscode.languages.createDiagnosticCollection("gdscript-lint");
+
 	const formatter = new GDScriptFormatter();
+	const linter = new GDScriptLinter();
 
 	vscode.workspace.onDidChangeConfiguration(event => {
 		let affected = event.affectsConfiguration("godotFormatter");
@@ -20,10 +24,38 @@ export function activate(context: vscode.ExtensionContext) {
 			return;
 		}
 		formatter.updateConfig();
+		linter.updateConfig();
 	});
 
-	const subscription = vscode.languages.registerDocumentFormattingEditProvider("gdscript", formatter);
-	context.subscriptions.push(subscription);
+	// Register formatter
+	const formatterSubscription = vscode.languages.registerDocumentFormattingEditProvider("gdscript", formatter);
+	context.subscriptions.push(formatterSubscription);
+
+	// Register linter on save
+	const lintSubscription = vscode.workspace.onDidSaveTextDocument(document => {
+		if (document.languageId === "gdscript") {
+			linter.lintDocument(document);
+		}
+	});
+	context.subscriptions.push(lintSubscription);
+
+	// Also lint when document is opened
+	const openSubscription = vscode.workspace.onDidOpenTextDocument(document => {
+		if (document.languageId === "gdscript") {
+			linter.lintDocument(document);
+		}
+	});
+	context.subscriptions.push(openSubscription);
+
+	// Clear diagnostics when document is closed
+	const closeSubscription = vscode.workspace.onDidCloseTextDocument(document => {
+		if (document.languageId === "gdscript") {
+			diagnosticCollection.delete(document.uri);
+		}
+	});
+	context.subscriptions.push(closeSubscription);
+
+	context.subscriptions.push(diagnosticCollection);
 }
 
 export function deactivate() { }
@@ -45,7 +77,7 @@ class GDScriptFormatter implements vscode.DocumentFormattingEditProvider {
 
 	updateConfig() {
 		const config = vscode.workspace.getConfiguration("godotFormatter");
-		this.enabled = config.get<boolean>("enableFormatter", true);
+		this.enabled = config.get<boolean>("enabled", true);
 		this.indentSize = config.get<number>("indentSize", 4);
 		this.useSpaces = config.get<boolean>("useSpaces", false);
 		this.reorderCode = config.get<boolean>("reorderCode", false);
@@ -96,6 +128,115 @@ class GDScriptFormatter implements vscode.DocumentFormattingEditProvider {
 			cmd += " --safe";
 		}
 		return cmd;
+	}
+}
+
+class GDScriptLinter {
+	private enabled: boolean = true;
+	private gdscriptFormatterPath: string = DEFAULT_EXECUTABLE;
+	private useBuiltInBinary: boolean = true;
+	private maxLineLength: number = 100;
+	private ignoredRules: string = "";
+
+	constructor() {
+		this.updateConfig();
+	}
+
+	updateConfig() {
+		const config = vscode.workspace.getConfiguration("godotFormatter");
+		this.enabled = config.get<boolean>("enableLinter", true);
+		this.gdscriptFormatterPath = config.get<string>("gdscriptFormatterPath", DEFAULT_EXECUTABLE).trim() || DEFAULT_EXECUTABLE;
+		this.useBuiltInBinary = config.get<boolean>("useBuiltInBinary", true);
+		this.maxLineLength = config.get<number>("linterMaxLineLength", 100);
+		this.ignoredRules = config.get<string>("linterIgnoredRules", "").trim();
+	}
+
+	async lintDocument(document: vscode.TextDocument) {
+		if (!this.enabled) {
+			diagnosticCollection.delete(document.uri);
+			return;
+		}
+
+		try {
+			const diagnostics = await this.runLinter(document);
+			diagnosticCollection.set(document.uri, diagnostics);
+		} catch (error) {
+			outputChannel.appendLine(`Linting failed for ${document.fileName}: ${error}`);
+			// Clear diagnostics on error
+			diagnosticCollection.delete(document.uri);
+		}
+	}
+
+	private runLinter(document: vscode.TextDocument): Promise<vscode.Diagnostic[]> {
+		return new Promise((resolve, reject) => {
+			const command = this.getLintCommand(document.fileName);
+
+			childProcess.exec(command, { encoding: "utf8" }, (err, stdout, stderr) => {
+				if (err && err.code !== 1) {
+					// Code 1 is expected when there are lint issues, other codes are actual errors
+					reject(new Error(`Linter command failed: ${err.message}`));
+					return;
+				}
+
+				const diagnostics = this.parseLintOutput(stdout, document);
+				resolve(diagnostics);
+			});
+		});
+	}
+
+	private getLintCommand(fileName: string): string {
+		let executable = BUILT_IN_BINARY_PATH;
+		if (!this.useBuiltInBinary) {
+			executable = this.gdscriptFormatterPath;
+		}
+
+		let command = `${executable} lint "${fileName}" --max-line-length ${this.maxLineLength}`;
+
+		if (this.ignoredRules) {
+			command += ` --disable ${this.ignoredRules}`;
+		}
+
+		return command;
+	}
+
+	private parseLintOutput(output: string, document: vscode.TextDocument): vscode.Diagnostic[] {
+		const diagnostics: vscode.Diagnostic[] = [];
+
+		if (!output.trim()) {
+			return diagnostics;
+		}
+
+		const lines = output.trim().split("\n");
+
+		for (const line of lines) {
+			// Parse format: file:line:lint:severity(error|warning): message
+			const match = line.match(/^(.+?):(\d+):([^:]+):(error|warning):\s*(.+)$/);
+
+			if (match) {
+				const [, , lineStr, lintType, severity, message] = match;
+				const lineNumber = parseInt(lineStr, 10) - 1; // VS Code uses 0-based line numbers
+
+				if (lineNumber >= 0 && lineNumber < document.lineCount) {
+					const range = new vscode.Range(
+						new vscode.Position(lineNumber, 0),
+						new vscode.Position(lineNumber, document.lineAt(lineNumber).text.length)
+					);
+
+					const diagnostic = new vscode.Diagnostic(
+						range,
+						`[${lintType}] ${message}`,
+						severity === "error" ? vscode.DiagnosticSeverity.Error : vscode.DiagnosticSeverity.Warning
+					);
+
+					diagnostic.source = "gdscript-formatter";
+					diagnostic.code = lintType;
+
+					diagnostics.push(diagnostic);
+				}
+			}
+		}
+
+		return diagnostics;
 	}
 }
 


### PR DESCRIPTION
With version `0.12.0` of GDScript-formatter, I added a `lint` command.

This uses the `lint` command to lint the open file when it is opened and when it is saved, and then displays the error on the line.

<img width="794" height="219" alt="Screenshot 2025-10-03 at 11 07 05 PM" src="https://github.com/user-attachments/assets/1716b67b-aace-4ccd-98f4-f36dc8bf30ad" />
